### PR TITLE
feat: add LspInlayHint highlight group

### DIFF
--- a/lua/nord/lsp.lua
+++ b/lua/nord/lsp.lua
@@ -25,6 +25,7 @@ function lsp.highlights()
     DiagnosticUnderlineHint = { undercurl = true, sp = c.frost.artic_water }, -- Used to underline "Hint" diagnostics
 
     LspCodeLens = { fg = c.polar_night.brightest },
+    LspInlayHint = { fg = c.polar_night.brightest },
 
     -- ray-x/lsp_signature.nvim
     LspSignatureActiveParameter = { bg = c.polar_night.brighter, bold = true },


### PR DESCRIPTION
On Neovim >v10, LspInlayHint is a group used for the build-in inlay hint colors. This also will allow for overriding in the `on_highlights` config.

Closes #55 