### PR TITLE
Fix highlight of added text in diff

### DIFF
--- a/lua/nord/treesitter.lua
+++ b/lua/nord/treesitter.lua
@@ -124,7 +124,7 @@ function treesitter.highlights()
     ["@text.danger"] = { link = "@comment.error" }, -- @deprecated
     ["@text.diff.add"] = { link = "DiffAdd" }, --  added text (for diff files)
     ["@text.diff.delete"] = { link = "DiffDelete" }, --  deleted text (for diff files)
-    ["@diff.diff"] = { link = "DiffAdd" }, --  added text (for diff files)
+    ["@diff.plus"] = { link = "DiffAdd" }, --  added text (for diff files)
     ["@diff.minus"] = { link = "DiffDelete" }, --  deleted text (for diff files)
     ["@diff.delta"] = { link = "DiffChange" },
 


### PR DESCRIPTION
When opening diffs (or using `git commit --verbose`) added lines were not highlighted correctly (at all?) as the link `@diff.plus` is not set up.

Steps to reproduce:
1. open [test.diff.txt](https://github.com/gbprod/nord.nvim/files/14076024/test.diff.txt) (after removing the `.txt` suffix or `:set ft=diff`) with current main: line 2 and 5 are not highlighted
2. `:hi link @diff.plus DiffAdd` manually and it uses the correct green color

I've kept the old link of `@diff.diff` to `DiffAdd` as this might be used by older versions (but I'm not sure on this).