### PR TITLE
feat: Add type annotation for color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,12 @@ require("nord").setup({
   },
 
   -- Override the default colors
+  ---@param colors Nord.Palette
   on_colors = function(colors) end,
 
   --- You can override specific highlights to use other groups or a hex color
   --- function will be called with all highlights and the colorScheme table
+  ---@param colors Nord.Palette
   on_highlights = function(highlights, colors) end,
 })
 ```

--- a/lua/nord/colors.lua
+++ b/lua/nord/colors.lua
@@ -1,5 +1,38 @@
 local colors = {}
 
+---@class Nord.Palette.PolarNight
+---@field origin string nord 0
+---@field bright string nord 1
+---@field brighter string nord 2
+---@field brightest string  nord 3
+---@field light string out of palette
+
+---@class Nord.Palette.SnowStorm
+---@field origin string  nord 4
+---@field brighter string nord 5
+---@field brightest string  nord 6
+
+---@class Nord.Palette.Frost
+---@field polar_water string nord 7
+---@field ice string nord 8
+---@field artic_water string nord 9
+---@field artic_ocean string nord 10
+
+---@class Nord.Palette.Aurora
+---@field red string nord 11
+---@field orange string nord 12
+---@field yellow string nord 13
+---@field green string nord 14
+---@field purple string nord 15
+
+---@class Nord.Palette
+---@field polar_night Nord.Palette.PolarNight
+---@field snow_storm Nord.Palette.SnowStorm
+---@field frost Nord.Palette.Frost
+---@field aurora Nord.Palette.Aurora
+---@field none string
+
+---@type Nord.Palette
 local defaults = {
   polar_night = {
     origin = "#2E3440", -- nord0


### PR DESCRIPTION
Introduces type annotations to the color palette, enabling LSP functionalities in the on_highlights and on_color functions.

<img width="862" alt="Screenshot 2024-11-26 at 14 40 16" src="https://github.com/user-attachments/assets/6e78d179-a7c5-490a-a06b-94758a8acee7">
