### PR TITLE
fix: SnacksExplorer hidden files hard to read

### DIFF
--- a/lua/nord/plugins/snacks.lua
+++ b/lua/nord/plugins/snacks.lua
@@ -11,6 +11,10 @@ function snacks.highlights()
     SnacksPickerBufFlags = { link = "Comment" },
     SnacksPickerKeymapRhs = { link = "Comment" },
     SnacksPickerGitStatus = { link = "Comment" },
+    SnacksPickerPathHidden = { link = "Comment" },
+    SnacksPickerPathIgnored = { link = "Comment" },
+    SnacksPickerGitStatusIgnored = { link = "Comment" },
+    SnacksPickerGitStatusUntracked = { link = "Comment" },
   }
 end
 


### PR DESCRIPTION
Added other Snacks highlight overrides specifically for explorer as files were hard to read the name of. 