### PR TITLE
feat: vimwiki

### DIFF
--- a/lua/nord/init.lua
+++ b/lua/nord/init.lua
@@ -42,7 +42,8 @@ function nord.load(opts)
     require("nord.plugins.mini").highlights(),
     require("nord.plugins.markview").highlights(),
     require("nord.plugins.snacks").highlights(),
-    require("nord.plugins.dap").highlights()
+    require("nord.plugins.dap").highlights(),
+    require("nord.plugins.vimwiki").highlights()
   )
 
   vim.g.colors_name = "nord"

--- a/lua/nord/plugins/vimwiki.lua
+++ b/lua/nord/plugins/vimwiki.lua
@@ -1,0 +1,22 @@
+local vimwiki = {}
+
+local c = require("nord.colors").palette
+
+function vimwiki.highlights()
+  return {
+    VimwikiLink = { fg = c.aurora.green, bg = c.none },
+    VimwikiHeaderChar = { fg = c.polar_night.light, bg = c.none },
+    VimwikiHR = { fg = c.aurora.yellow, bg = c.none },
+    VimwikiList = { fg = c.frost.artic_water, bg = c.none },
+    VimwikiTag = { fg = c.aurora.green, bg = c.none },
+    VimwikiMarkers = { fg = c.frost.artic_ocean, bg = c.none },
+    VimwikiHeader1 = { fg = c.frost.artic_ocean, bg = c.none, bold = true },
+    VimwikiHeader2 = { fg = c.frost.artic_water, bg = c.none, bold = true },
+    VimwikiHeader3 = { fg = c.frost.ice, bg = c.none, bold = true },
+    VimwikiHeader4 = { fg = c.frost.polar_water, bg = c.none, bold = true },
+    VimwikiHeader5 = { fg = c.polar_night.light, bg = c.none, bold = true },
+    VimwikiHeader6 = { fg = c.polar_night.brightest, bg = c.none, bold = true },
+  }
+end
+
+return vimwiki


### PR DESCRIPTION
Support for [vimwiki](https://github.com/vimwiki/vimwiki)
Reference from [folke/tokyonight.nvim](https://github.com/folke/tokyonight.nvim)

Use frost colors for headers highlight but since frost only has four colors, header4 and header5 will be using polar night colors instead. It somehow makes them a bit inconsistent. If there is any better choice for the headers color, please let me know.