### PR TITLE
fix fzf-lua border bg when transparent is set to true

### DIFF
--- a/lua/nord/plugins/picker.lua
+++ b/lua/nord/plugins/picker.lua
@@ -10,7 +10,7 @@ function picker.highlights()
     TelescopePromptCounter = { fg = c.polar_night.light },
     TelescopeMatching = { fg = c.frost.ice, bold = true },
 
-    FzfLuaBorder = { fg = c.polar_night.light, bg = utils.make_global_bg() },
+    FzfLuaBorder = { fg = c.polar_night.light, bg = utils.make_global_bg(true) },
     FzfLuaTitle = { fg = c.snow_storm.origin, bold = true },
     FzfLuaHeaderBind = { fg = c.frost.ice },
     FzfLuaHeaderText = { fg = c.frost.artic_ocean },


### PR DESCRIPTION
Before
<img width="2114" height="1277" alt="Screenshot_20250929-194651" src="https://github.com/user-attachments/assets/003c2231-75c7-4d65-bd90-6bc3976a965e" />

After
<img width="2073" height="1254" alt="Screenshot_20250929-195202" src="https://github.com/user-attachments/assets/e47994b6-7deb-4f75-a075-01d661ab604e" />
