### PR TITLE
feat: treesitter add markdown heading, link, checklist and support render markdown

### DIFF
--- a/lua/nord/init.lua
+++ b/lua/nord/init.lua
@@ -43,7 +43,8 @@ function nord.load(opts)
     require("nord.plugins.markview").highlights(),
     require("nord.plugins.snacks").highlights(),
     require("nord.plugins.dap").highlights(),
-    require("nord.plugins.vimwiki").highlights()
+    require("nord.plugins.vimwiki").highlights(),
+    require("nord.plugins.render-markdown").highlights()
   )
 
   vim.g.colors_name = "nord"

--- a/lua/nord/plugins/render-markdown.lua
+++ b/lua/nord/plugins/render-markdown.lua
@@ -1,0 +1,19 @@
+local render_markdown = {}
+local c = require("nord.colors").palette
+local utils = require("nord.utils")
+
+function render_markdown.highlights()
+  return {
+    RenderMarkdownBullet = { fg = c.frost.artic_water },
+    RenderMarkdownQuote = { fg = c.polar_night.light },
+    RenderMarkdownTodo = { fg = c.snow_storm.origin },
+    RenderMarkdownH1Bg = { bg = utils.darken(c.frost.artic_water, 0.2) },
+    RenderMarkdownH2Bg = { bg = utils.darken(c.aurora.purple, 0.2) },
+    RenderMarkdownH3Bg = { bg = utils.darken(c.aurora.green, 0.2) },
+    RenderMarkdownH4Bg = { bg = utils.darken(c.aurora.yellow, 0.2) },
+    RenderMarkdownH5Bg = { bg = utils.darken(c.aurora.orange, 0.2) },
+    RenderMarkdownH6Bg = { bg = utils.darken(c.aurora.red, 0.2) },
+  }
+end
+
+return render_markdown

--- a/lua/nord/treesitter.lua
+++ b/lua/nord/treesitter.lua
@@ -21,6 +21,8 @@ function treesitter.highlights()
     ["@punctuation.delimiter"] = { fg = c.snow_storm.brightest }, --  delimiters (e.g. `;` / `.` / `,`)
     ["@punctuation.bracket"] = { fg = c.frost.ice }, --  brackets (e.g. `()` / `{}` / `[]`)
     ["@markup.list"] = { fg = c.frost.artic_water }, --  special symbols (e.g. `{}` in string interpolation)
+    ["@markup.list.unchecked"] = { fg = c.frost.ice }, --  unchecked list
+    ["@markup.list.checked"] = { fg = c.frost.polar_water }, --  checked list
     ["@punctuation.special"] = { link = "@markup.list" }, -- @deprecated
 
     -- Literals
@@ -101,11 +103,18 @@ function treesitter.highlights()
     ["@markup.strikethrough"] = { strikethrough = true }, --  strikethrough text
     ["@text.strike"] = { link = "@markup.strikethrough" }, -- @deprecated
     ["@markup.heading"] = { fg = c.frost.ice, bold = true }, --  text that is part of a title
+    ["@markup.heading.1.markdown"] = { fg = c.frost.artic_water, bold = true }, --  markdown h1
+    ["@markup.heading.2.markdown"] = { fg = c.aurora.purple, bold = true }, --  markdown h2
+    ["@markup.heading.3.markdown"] = { fg = c.aurora.green, bold = true }, --  markdown h3
+    ["@markup.heading.4.markdown"] = { fg = c.aurora.yellow, bold = true }, --  markdown h4
+    ["@markup.heading.5.markdown"] = { fg = c.aurora.orange, bold = true }, --  markdown h5
+    ["@markup.heading.6.markdown"] = { fg = c.aurora.red, bold = true }, --  markdown h6
     ["@text.title"] = { link = "@markup.heading" }, -- @deprecated
     ["@markup.raw"] = { fg = c.frost.polar_water }, --  literal or verbatim text
     ["@text.literal"] = { link = "@markup.raw" }, -- @deprecated
     ["@markup.link.url"] = { fg = c.aurora.green, underline = true, sp = c.aurora.green }, --  URIs (e.g. hyperlinks)
     ["@text.uri"] = { link = "@markup.link.url" }, -- @deprecated
+    ["@markup.link.label.markdown_inline"] = { fg = c.aurora.green }, --  markdown link
     ["@markup.math"] = { fg = c.frost.polar_water }, --  math environments (e.g. `$ ... $` in LaTeX)
     ["@text.math"] = { link = "@markup.math" }, -- @deprecated
     ["@markup.environment"] = { fg = c.frost.polar_water }, --  text environments of markup languages


### PR DESCRIPTION
#96

markdown
<img width="935" height="680" alt="Screenshot_20251015-170053" src="https://github.com/user-attachments/assets/8071b1a6-0b46-4709-915f-983ab8ff21d4" />

with render-markdown
<img width="1858" height="1238" alt="Screenshot_20251015-170626" src="https://github.com/user-attachments/assets/a06f56b2-5294-4ebb-a5f7-63dd18988344" />
