### PR TITLE
feat: Add light theme variant support

### DIFF
--- a/lua/lualine/themes/nord-light.lua
+++ b/lua/lualine/themes/nord-light.lua
@@ -1,0 +1,3 @@
+-- Delegate to the main nord theme which handles both dark and light styles.
+local path = vim.api.nvim_get_runtime_file("lua/lualine/themes/nord.lua", false)[1]
+return dofile(path)

--- a/lua/lualine/themes/nord.lua
+++ b/lua/lualine/themes/nord.lua
@@ -32,6 +32,19 @@ nord.inactive = {
   c = { fg = c.snow_storm.origin, bg = c.polar_night.bright },
 }
 
+-- Apply light theme adjustments
+if require("nord.config").options.style == "light" then
+  for _, mode in pairs(nord) do
+    for _, highlight in pairs(mode) do
+      if highlight.fg and highlight.bg then
+        local temp = highlight.fg
+        highlight.fg = highlight.bg
+        highlight.bg = temp
+      end
+    end
+  end
+end
+
 if config.lualine_bold then
   for _, mode in pairs(nord) do
     mode.a.gui = "bold"

--- a/lua/lualine/themes/nord.lua
+++ b/lua/lualine/themes/nord.lua
@@ -1,54 +1,50 @@
-local c = require("nord.colors").palette
-local utils = require("nord.utils")
-local config = require("nord.config").options.styles
+local function get_colors()
+  local colors = require("nord.colors")
+  local config = require("nord.config")
+  return config.options.style == "light" and colors.light_palette or colors.palette
+end
 
-local nord = {}
+local function get_theme()
+  local c = get_colors()
+  local config = require("nord.config")
 
-nord.normal = {
-  a = { fg = c.polar_night.bright, bg = c.frost.ice },
-  b = { fg = c.snow_storm.brighter, bg = c.polar_night.bright },
-  c = { fg = c.snow_storm.brighter, bg = c.polar_night.brighter },
-}
+  local nord = {}
 
-nord.insert = {
-  a = { fg = c.polar_night.bright, bg = c.snow_storm.origin },
-}
+  nord.normal = {
+    a = { fg = c.polar_night.bright, bg = c.frost.ice },
+    b = { fg = c.snow_storm.brighter, bg = c.polar_night.bright },
+    c = { fg = c.snow_storm.brighter, bg = c.polar_night.brighter },
+  }
 
-nord.visual = {
-  a = { fg = c.polar_night.bright, bg = c.frost.polar_water },
-}
+  nord.insert = {
+    a = { fg = c.polar_night.bright, bg = c.snow_storm.origin },
+  }
 
-nord.replace = {
-  a = { fg = c.polar_night.bright, bg = c.aurora.yellow },
-}
+  nord.visual = {
+    a = { fg = c.polar_night.bright, bg = c.frost.polar_water },
+  }
 
-nord.command = {
-  a = { fg = c.polar_night.bright, bg = c.aurora.purple },
-}
+  nord.replace = {
+    a = { fg = c.polar_night.bright, bg = c.aurora.yellow },
+  }
 
-nord.inactive = {
-  a = { fg = c.snow_storm.origin, bg = utils.make_global_bg() },
-  b = { fg = c.snow_storm.origin, bg = utils.make_global_bg() },
-  c = { fg = c.snow_storm.origin, bg = c.polar_night.bright },
-}
+  nord.command = {
+    a = { fg = c.polar_night.bright, bg = c.aurora.purple },
+  }
 
--- Apply light theme adjustments
-if require("nord.config").options.style == "light" then
-  for _, mode in pairs(nord) do
-    for _, highlight in pairs(mode) do
-      if highlight.fg and highlight.bg then
-        local temp = highlight.fg
-        highlight.fg = highlight.bg
-        highlight.bg = temp
-      end
+  nord.inactive = {
+    a = { fg = c.snow_storm.origin, bg = c.polar_night.origin },
+    b = { fg = c.snow_storm.origin, bg = c.polar_night.origin },
+    c = { fg = c.snow_storm.origin, bg = c.polar_night.bright },
+  }
+
+  if config.options.styles and config.options.styles.lualine_bold then
+    for _, mode in pairs(nord) do
+      mode.a.gui = "bold"
     end
   end
+
+  return nord
 end
 
-if config.lualine_bold then
-  for _, mode in pairs(nord) do
-    mode.a.gui = "bold"
-  end
-end
-
-return nord
+return get_theme()

--- a/lua/nord/colors.lua
+++ b/lua/nord/colors.lua
@@ -62,7 +62,33 @@ local defaults = {
   none = "NONE",
 }
 
+---@type Nord.Palette
+local light_palette = {
+  polar_night = {
+    origin = "#ECEFF4",
+    bright = "#E5E9F0",
+    brighter = "#D8DEE9",
+    brightest = "#D8DEE9",
+    light = "#D8DEE9",
+  },
+  snow_storm = {
+    origin = "#434C5E",
+    brighter = "#3B4252",
+    brightest = "#2E3440",
+  },
+  frost = vim.tbl_extend("force", {}, defaults.frost),
+  aurora = {
+    red = "#BF616A",
+    orange = "#D08770",
+    yellow = "#EBCB8B",
+    green = "#A3BE8C",
+    purple = "#B48EAD",
+  },
+  none = "NONE",
+}
+
 colors.palette = defaults
+colors.light_palette = light_palette
 colors.default_bg = "#2E3440" -- nord0
 
 function colors.daltonize(severity)
@@ -75,6 +101,52 @@ function colors.daltonize(severity)
       end
     end
   end
+end
+
+function colors.apply_style()
+  if require("nord.config").options.style == "light" then
+    colors.default_bg = light_palette.polar_night.origin
+
+    -- Use darkened aurora colors for light background
+    colors.palette.aurora = {
+      red = "#A3253F",
+      orange = "#B85C3C",
+      yellow = "#B39A00",
+      green = "#6B7C3A",
+      purple = "#8B4E6C",
+    }
+  end
+end
+
+function colors.invert_highlight_for_light(highlight)
+  if require("nord.config").options.style ~= "light" then
+    return highlight
+  end
+
+  local inverted = vim.tbl_extend("force", {}, highlight)
+
+  -- Bidirectional color mapping for light mode
+  local color_map = {
+    -- Polar Night to Snow Storm
+    ["#2E3440"] = "#ECEFF4", -- polar_night.origin -> snow_storm.brightest
+    ["#3B4252"] = "#E5E9F0", -- polar_night.bright -> snow_storm.brighter
+    ["#434C5E"] = "#D8DEE9", -- polar_night.brighter -> snow_storm.origin
+    ["#4C566A"] = "#D8DEE9", -- polar_night.brightest -> snow_storm.origin
+
+    -- Snow Storm to Polar Night
+    ["#D8DEE9"] = "#434C5E", -- snow_storm.origin -> polar_night.brighter
+    ["#E5E9F0"] = "#3B4252", -- snow_storm.brighter -> polar_night.bright
+    ["#ECEFF4"] = "#2E3440", -- snow_storm.brightest -> polar_night.origin
+  }
+
+  if inverted.fg and color_map[inverted.fg] then
+    inverted.fg = color_map[inverted.fg]
+  end
+  if inverted.bg and color_map[inverted.bg] then
+    inverted.bg = color_map[inverted.bg]
+  end
+
+  return inverted
 end
 
 return colors

--- a/lua/nord/colors.lua
+++ b/lua/nord/colors.lua
@@ -6,6 +6,7 @@ local colors = {}
 ---@field brighter string nord 2
 ---@field brightest string  nord 3
 ---@field light string out of palette
+---@field comment string out of palette, light-mode comment color
 
 ---@class Nord.Palette.SnowStorm
 ---@field origin string  nord 4
@@ -62,34 +63,54 @@ local defaults = {
   none = "NONE",
 }
 
+-- Light palette: polar_night/snow_storm are semantically swapped so that
+-- polar_night fields = light backgrounds and snow_storm fields = dark text.
+-- Frost is identical. Aurora uses darkened variants readable on light bg.
 ---@type Nord.Palette
 local light_palette = {
   polar_night = {
-    origin = "#ECEFF4",
+    origin = "#ECEFF4",  -- lightest bg
     bright = "#E5E9F0",
     brighter = "#D8DEE9",
     brightest = "#D8DEE9",
     light = "#D8DEE9",
+    comment = "#60728A", -- muted blue-grey, readable on light bg
   },
   snow_storm = {
-    origin = "#434C5E",
+    origin = "#434C5E",  -- darkest text
     brighter = "#3B4252",
     brightest = "#2E3440",
   },
   frost = vim.tbl_extend("force", {}, defaults.frost),
   aurora = {
-    red = "#BF616A",
-    orange = "#D08770",
-    yellow = "#EBCB8B",
-    green = "#A3BE8C",
-    purple = "#B48EAD",
+    red = "#A3253F",
+    orange = "#B85C3C",
+    yellow = "#B39A00",
+    green = "#6B7C3A",
+    purple = "#8B4E6C",
   },
   none = "NONE",
 }
 
 colors.palette = defaults
 colors.light_palette = light_palette
-colors.default_bg = "#2E3440" -- nord0
+colors.default_bg = defaults.polar_night.origin
+
+-- Built once at module load; maps dark palette hex values to their light
+-- equivalents and vice-versa for use in invert_highlight_for_light().
+local color_map = {
+  -- Polar Night (dark backgrounds) -> Snow Storm (light backgrounds)
+  [defaults.polar_night.origin]   = light_palette.polar_night.origin,
+  [defaults.polar_night.bright]   = light_palette.polar_night.bright,
+  [defaults.polar_night.brighter] = light_palette.polar_night.brighter,
+  [defaults.polar_night.brightest]= light_palette.polar_night.brightest,
+  [defaults.polar_night.light]    = light_palette.polar_night.comment,
+
+  -- Snow Storm (light text) -> Polar Night (dark text)
+  [defaults.snow_storm.origin]    = light_palette.snow_storm.origin,
+  [defaults.snow_storm.brighter]  = light_palette.snow_storm.brighter,
+  [defaults.snow_storm.brightest] = light_palette.snow_storm.brightest,
+}
 
 function colors.daltonize(severity)
   local daltonize = require("nord.utils.colorblind").daltonize
@@ -106,15 +127,8 @@ end
 function colors.apply_style()
   if require("nord.config").options.style == "light" then
     colors.default_bg = light_palette.polar_night.origin
-
-    -- Use darkened aurora colors for light background
-    colors.palette.aurora = {
-      red = "#A3253F",
-      orange = "#B85C3C",
-      yellow = "#B39A00",
-      green = "#6B7C3A",
-      purple = "#8B4E6C",
-    }
+    -- Switch to darkened aurora colors readable on a light background.
+    colors.palette.aurora = light_palette.aurora
   end
 end
 
@@ -124,20 +138,6 @@ function colors.invert_highlight_for_light(highlight)
   end
 
   local inverted = vim.tbl_extend("force", {}, highlight)
-
-  -- Bidirectional color mapping for light mode
-  local color_map = {
-    -- Polar Night to Snow Storm
-    ["#2E3440"] = "#ECEFF4", -- polar_night.origin -> snow_storm.brightest
-    ["#3B4252"] = "#E5E9F0", -- polar_night.bright -> snow_storm.brighter
-    ["#434C5E"] = "#D8DEE9", -- polar_night.brighter -> snow_storm.origin
-    ["#4C566A"] = "#D8DEE9", -- polar_night.brightest -> snow_storm.origin
-
-    -- Snow Storm to Polar Night
-    ["#D8DEE9"] = "#434C5E", -- snow_storm.origin -> polar_night.brighter
-    ["#E5E9F0"] = "#3B4252", -- snow_storm.brighter -> polar_night.bright
-    ["#ECEFF4"] = "#2E3440", -- snow_storm.brightest -> polar_night.origin
-  }
 
   if inverted.fg and color_map[inverted.fg] then
     inverted.fg = color_map[inverted.fg]

--- a/lua/nord/config.lua
+++ b/lua/nord/config.lua
@@ -2,6 +2,7 @@ local config = {}
 
 local defaults = {
   transparent = false, -- Enable this to disable setting the background color
+  style = "dark", -- [dark|light]
   terminal_colors = true, -- Configure the colors used when opening a `:terminal` in Neovim
   diff = { mode = "bg" }, -- [bg|fg]
   search = { theme = "vim" }, -- [vim|vscode]

--- a/lua/nord/init.lua
+++ b/lua/nord/init.lua
@@ -1,34 +1,45 @@
 local config = require("nord.config")
 local utils = require("nord.utils")
+local colors = require("nord.colors")
+local terminal = require("nord.terminal")
 
 local nord = {}
 
 function nord.load(opts)
   if opts then
-    require("nord.config").extend(opts)
+    config.extend(opts)
   end
 
   vim.o.termguicolors = true
 
   if config.options.colorblind.enable then
-    require("nord.colors").daltonize(config.options.colorblind.severity)
+    colors.daltonize(config.options.colorblind.severity)
   end
 
-  require("nord.colors").apply_style()
-  require("nord.config").options.on_colors(require("nord.colors").palette)
+  colors.apply_style()
+  config.options.on_colors(colors.palette)
 
-  vim.cmd([[ highlight clear ]])
+  -- Silence lualine's ColorScheme/OptionSet autocmds while we apply the theme,
+  -- so intermediate events (highlight clear, background change) don't trigger
+  -- a premature lualine reload with stale highlights.
+  vim.cmd([[augroup lualine | exe "autocmd!" | augroup END]])
+
+  -- Set background before highlight clear so Neovim resets to the correct
+  -- base defaults (light or dark) and downstream plugins know the variant.
+  vim.o.background = config.options.style == "light" and "light" or "dark"
+
+  vim.cmd([[highlight clear]])
 
   if config.options.terminal_colors then
-    require("nord.terminal").apply()
-    require("nord.terminal").apply_light_adjustments()
+    terminal.apply()
+    terminal.apply_light_adjustments()
   end
 
   utils.load(
     utils.apply_light_mode(require("nord.defaults").highlights()),
     utils.apply_light_mode(require("nord.lsp").highlights()),
     utils.apply_light_mode(require("nord.syntax").highlights()),
-    utils.apply_light_mode(require("nord.terminal").highlights()),
+    utils.apply_light_mode(terminal.highlights()),
     utils.apply_light_mode(require("nord.treesitter").highlights()),
     utils.apply_light_mode(require("nord.plugins.bufferline").highlights()),
     utils.apply_light_mode(require("nord.plugins.completion").highlights()),
@@ -49,8 +60,18 @@ function nord.load(opts)
     utils.apply_light_mode(require("nord.plugins.render-markdown").highlights())
   )
 
-  local style = config.options.style == "light" and "-light" or ""
-  vim.g.colors_name = "nord" .. style
+  -- Always "nord" so lualine's auto theme resolves to lualine/themes/nord.lua.
+  vim.g.colors_name = "nord"
+
+  -- Re-register lualine's ColorScheme/OptionSet autocmds (cleared above) and
+  -- reload its theme once all highlights are in place. Deferred so plugins
+  -- like Snacks that lualine may reference are guaranteed to be loaded.
+  vim.schedule(function()
+    local ok, lualine = pcall(require, "lualine")
+    if ok and lualine.get_config then
+      lualine.setup(lualine.get_config())
+    end
+  end)
 end
 
 nord.setup = config.setup

--- a/lua/nord/init.lua
+++ b/lua/nord/init.lua
@@ -14,40 +14,43 @@ function nord.load(opts)
     require("nord.colors").daltonize(config.options.colorblind.severity)
   end
 
+  require("nord.colors").apply_style()
   require("nord.config").options.on_colors(require("nord.colors").palette)
 
   vim.cmd([[ highlight clear ]])
 
   if config.options.terminal_colors then
     require("nord.terminal").apply()
+    require("nord.terminal").apply_light_adjustments()
   end
 
   utils.load(
-    require("nord.defaults").highlights(),
-    require("nord.lsp").highlights(),
-    require("nord.syntax").highlights(),
+    utils.apply_light_mode(require("nord.defaults").highlights()),
+    utils.apply_light_mode(require("nord.lsp").highlights()),
+    utils.apply_light_mode(require("nord.syntax").highlights()),
     require("nord.terminal").highlights(),
-    require("nord.treesitter").highlights(),
-    require("nord.plugins.bufferline").highlights(),
-    require("nord.plugins.completion").highlights(),
-    require("nord.plugins.filetree").highlights(),
-    require("nord.plugins.git").highlights(),
-    require("nord.plugins.motion").highlights(),
-    require("nord.plugins.notify").highlights(),
-    require("nord.plugins.picker").highlights(),
-    require("nord.plugins.ui").highlights(),
-    require("nord.plugins.diffview").highlights(),
-    require("nord.plugins.neogit").highlights(),
-    require("nord.plugins.glance").highlights(),
-    require("nord.plugins.mini").highlights(),
-    require("nord.plugins.markview").highlights(),
-    require("nord.plugins.snacks").highlights(),
-    require("nord.plugins.dap").highlights(),
-    require("nord.plugins.vimwiki").highlights(),
-    require("nord.plugins.render-markdown").highlights()
+    utils.apply_light_mode(require("nord.treesitter").highlights()),
+    utils.apply_light_mode(require("nord.plugins.bufferline").highlights()),
+    utils.apply_light_mode(require("nord.plugins.completion").highlights()),
+    utils.apply_light_mode(require("nord.plugins.filetree").highlights()),
+    utils.apply_light_mode(require("nord.plugins.git").highlights()),
+    utils.apply_light_mode(require("nord.plugins.motion").highlights()),
+    utils.apply_light_mode(require("nord.plugins.notify").highlights()),
+    utils.apply_light_mode(require("nord.plugins.picker").highlights()),
+    utils.apply_light_mode(require("nord.plugins.ui").highlights()),
+    utils.apply_light_mode(require("nord.plugins.diffview").highlights()),
+    utils.apply_light_mode(require("nord.plugins.neogit").highlights()),
+    utils.apply_light_mode(require("nord.plugins.glance").highlights()),
+    utils.apply_light_mode(require("nord.plugins.mini").highlights()),
+    utils.apply_light_mode(require("nord.plugins.markview").highlights()),
+    utils.apply_light_mode(require("nord.plugins.snacks").highlights()),
+    utils.apply_light_mode(require("nord.plugins.dap").highlights()),
+    utils.apply_light_mode(require("nord.plugins.vimwiki").highlights()),
+    utils.apply_light_mode(require("nord.plugins.render-markdown").highlights())
   )
 
-  vim.g.colors_name = "nord"
+  local style = config.options.style == "light" and "-light" or ""
+  vim.g.colors_name = "nord" .. style
 end
 
 nord.setup = config.setup

--- a/lua/nord/init.lua
+++ b/lua/nord/init.lua
@@ -28,7 +28,7 @@ function nord.load(opts)
     utils.apply_light_mode(require("nord.defaults").highlights()),
     utils.apply_light_mode(require("nord.lsp").highlights()),
     utils.apply_light_mode(require("nord.syntax").highlights()),
-    require("nord.terminal").highlights(),
+    utils.apply_light_mode(require("nord.terminal").highlights()),
     utils.apply_light_mode(require("nord.treesitter").highlights()),
     utils.apply_light_mode(require("nord.plugins.bufferline").highlights()),
     utils.apply_light_mode(require("nord.plugins.completion").highlights()),

--- a/lua/nord/lsp.lua
+++ b/lua/nord/lsp.lua
@@ -5,6 +5,15 @@ local c = require("nord.colors").palette
 local light_c = require("nord.colors").light_palette
 
 function lsp.highlights()
+  local is_light = require("nord.config").options.style == "light"
+
+  local function vtext(color, light_color)
+    if is_light then
+      return { bg = c.none, fg = light_color }
+    end
+    return { bg = utils.darken(color, 0.1), fg = color }
+  end
+
   return {
     -- LspReferenceText = { bg = c.fg_gutter }, -- used for highlighting "text" references
     -- LspReferenceRead = { bg = c.fg_gutter }, -- used for highlighting "read" references
@@ -16,18 +25,10 @@ function lsp.highlights()
     DiagnosticInfo = { fg = c.frost.ice }, -- Used as the base highlight group. Other Diagnostic highlights link to this by default
     DiagnosticHint = { fg = c.frost.artic_water }, -- Used as the base highlight group. Other Diagnostic highlights link to this by default
 
-    DiagnosticVirtualTextError = require("nord.config").options.style == "light"
-      and { bg = c.none, fg = light_c.aurora.red }
-      or { bg = utils.darken(c.aurora.red, 0.1), fg = c.aurora.red }, -- Used for "Error" diagnostic virtual text
-    DiagnosticVirtualTextWarn = require("nord.config").options.style == "light"
-      and { bg = c.none, fg = light_c.aurora.yellow }
-      or { bg = utils.darken(c.aurora.yellow, 0.1), fg = c.aurora.yellow }, -- Used for "Warning" diagnostic virtual text
-    DiagnosticVirtualTextInfo = require("nord.config").options.style == "light"
-      and { bg = c.none, fg = light_c.frost.ice }
-      or { bg = utils.darken(c.frost.ice, 0.1), fg = c.frost.ice }, -- Used for "Information" diagnostic virtual text
-    DiagnosticVirtualTextHint = require("nord.config").options.style == "light"
-      and { bg = c.none, fg = light_c.frost.artic_water }
-      or { bg = utils.darken(c.frost.artic_water, 0.1), fg = c.frost.artic_water }, -- Used for "Hint" diagnostic virtual text
+    DiagnosticVirtualTextError = vtext(c.aurora.red, light_c.aurora.red), -- Used for "Error" diagnostic virtual text
+    DiagnosticVirtualTextWarn = vtext(c.aurora.yellow, light_c.aurora.yellow), -- Used for "Warning" diagnostic virtual text
+    DiagnosticVirtualTextInfo = vtext(c.frost.ice, light_c.frost.ice), -- Used for "Information" diagnostic virtual text
+    DiagnosticVirtualTextHint = vtext(c.frost.artic_water, light_c.frost.artic_water), -- Used for "Hint" diagnostic virtual text
 
     DiagnosticUnderlineError = { undercurl = true, sp = c.aurora.red }, -- Used to underline "Error" diagnostics
     DiagnosticUnderlineWarn = { undercurl = true, sp = c.aurora.yellow }, -- Used to underline "Warning" diagnostics

--- a/lua/nord/lsp.lua
+++ b/lua/nord/lsp.lua
@@ -2,6 +2,7 @@ local utils = require("nord.utils")
 local lsp = {}
 
 local c = require("nord.colors").palette
+local light_c = require("nord.colors").light_palette
 
 function lsp.highlights()
   return {
@@ -15,10 +16,18 @@ function lsp.highlights()
     DiagnosticInfo = { fg = c.frost.ice }, -- Used as the base highlight group. Other Diagnostic highlights link to this by default
     DiagnosticHint = { fg = c.frost.artic_water }, -- Used as the base highlight group. Other Diagnostic highlights link to this by default
 
-    DiagnosticVirtualTextError = { bg = utils.darken(c.aurora.red, 0.1), fg = c.aurora.red }, -- Used for "Error" diagnostic virtual text
-    DiagnosticVirtualTextWarn = { bg = utils.darken(c.aurora.yellow, 0.1), fg = c.aurora.yellow }, -- Used for "Warning" diagnostic virtual text
-    DiagnosticVirtualTextInfo = { bg = utils.darken(c.frost.ice, 0.1), fg = c.frost.ice }, -- Used for "Information" diagnostic virtual text
-    DiagnosticVirtualTextHint = { bg = utils.darken(c.frost.artic_water, 0.1), fg = c.frost.artic_water }, -- Used for "Hint" diagnostic virtual text
+    DiagnosticVirtualTextError = require("nord.config").options.style == "light"
+      and { bg = c.none, fg = light_c.aurora.red }
+      or { bg = utils.darken(c.aurora.red, 0.1), fg = c.aurora.red }, -- Used for "Error" diagnostic virtual text
+    DiagnosticVirtualTextWarn = require("nord.config").options.style == "light"
+      and { bg = c.none, fg = light_c.aurora.yellow }
+      or { bg = utils.darken(c.aurora.yellow, 0.1), fg = c.aurora.yellow }, -- Used for "Warning" diagnostic virtual text
+    DiagnosticVirtualTextInfo = require("nord.config").options.style == "light"
+      and { bg = c.none, fg = light_c.frost.ice }
+      or { bg = utils.darken(c.frost.ice, 0.1), fg = c.frost.ice }, -- Used for "Information" diagnostic virtual text
+    DiagnosticVirtualTextHint = require("nord.config").options.style == "light"
+      and { bg = c.none, fg = light_c.frost.artic_water }
+      or { bg = utils.darken(c.frost.artic_water, 0.1), fg = c.frost.artic_water }, -- Used for "Hint" diagnostic virtual text
 
     DiagnosticUnderlineError = { undercurl = true, sp = c.aurora.red }, -- Used to underline "Error" diagnostics
     DiagnosticUnderlineWarn = { undercurl = true, sp = c.aurora.yellow }, -- Used to underline "Warning" diagnostics

--- a/lua/nord/terminal.lua
+++ b/lua/nord/terminal.lua
@@ -1,6 +1,7 @@
 local terminal = {}
 
 local c = require("nord.colors").palette
+local light_c = require("nord.colors").light_palette
 
 function terminal.apply()
   -- dark
@@ -31,9 +32,17 @@ function terminal.apply()
   vim.g.terminal_color_14 = c.frost.polar_water
 end
 
+function terminal.apply_light_adjustments()
+  if require("nord.config").options.style == "light" then
+    vim.g.terminal_color_0 = light_c.snow_storm.origin
+    vim.g.terminal_color_8 = light_c.snow_storm.brighter
+    vim.g.terminal_color_7 = light_c.polar_night.bright
+    vim.g.terminal_color_15 = light_c.polar_night.origin
+  end
+end
+
 function terminal.highlights()
   return {
-
     TermCursor = { fg = c.snow_storm.origin, bg = c.none, reverse = true }, -- cursor in a focused terminal
     TermCursorNC = { fg = c.polar_night.brightest, bg = c.none, reverse = true }, -- cursor in an unfocused terminal
   }

--- a/lua/nord/terminal.lua
+++ b/lua/nord/terminal.lua
@@ -1,7 +1,6 @@
 local terminal = {}
 
 local c = require("nord.colors").palette
-local light_c = require("nord.colors").light_palette
 
 function terminal.apply()
   -- dark
@@ -33,12 +32,17 @@ function terminal.apply()
 end
 
 function terminal.apply_light_adjustments()
-  if require("nord.config").options.style == "light" then
-    vim.g.terminal_color_0 = light_c.snow_storm.origin
-    vim.g.terminal_color_8 = light_c.snow_storm.brighter
-    vim.g.terminal_color_7 = light_c.polar_night.bright
-    vim.g.terminal_color_15 = light_c.polar_night.origin
+  if require("nord.config").options.style ~= "light" then
+    return
   end
+
+  -- In light mode swap the dark/light terminal base colors using light_palette,
+  -- which is the semantic inverse of the dark palette.
+  local light_c = require("nord.colors").light_palette
+  vim.g.terminal_color_0 = light_c.snow_storm.origin    -- dark terminal bg -> light text
+  vim.g.terminal_color_8 = light_c.snow_storm.brighter
+  vim.g.terminal_color_7 = light_c.polar_night.bright   -- light terminal bg -> dark bg
+  vim.g.terminal_color_15 = light_c.polar_night.origin
 end
 
 function terminal.highlights()

--- a/lua/nord/utils/init.lua
+++ b/lua/nord/utils/init.lua
@@ -70,4 +70,17 @@ function utils.make_global_bg(transparent)
   return c.polar_night.origin
 end
 
+function utils.apply_light_mode(highlights)
+  local colors = require("nord.colors")
+  if require("nord.config").options.style ~= "light" then
+    return highlights
+  end
+
+  for group, highlight in pairs(highlights) do
+    highlights[group] = colors.invert_highlight_for_light(highlight)
+  end
+
+  return highlights
+end
+
 return utils


### PR DESCRIPTION
## Description

Adds a light theme variant to nord.nvim, allowing users to switch between dark and light color schemes.

## Changes

- Add `style` config option (`"dark"` | `"light"`) to switch between themes
- Define `light_palette` with semantically inverted polar night/snow storm colors for light backgrounds, and darkened aurora colors for better readability
- Add named `light_palette.polar_night.comment` color for visible comments on light backgrounds
- Implement `invert_highlight_for_light()` with a module-level `color_map` to remap dark palette colors to their light equivalents across all highlight groups
- Add `apply_light_mode()` utility that applies the inversion to an entire highlight table
- Add `apply_style()` to switch `default_bg` and aurora colors when style is `"light"`
- Add `apply_light_adjustments()` in terminal to swap base terminal colors for light mode
- Set `vim.o.background in nord.load()` before `highlight clear` so Neovim resets to the correct base defaults
- Silence lualine's `ColorScheme`/`OptionSet` autocmds during highlight application, then do a single clean lualine reload via `vim.schedule` after all highlights are set
- Rewrite `lualine/themes/nord.lua` to resolve palette lazily via `get_theme()`, selecting `light_palette` or `palette` based on current style
- Add `lualine/themes/nord-light.lua` as a thin delegate to `nord.lua` via `dofile`
- Extract repeated `DiagnosticVirtualText` style logic in `lsp.lua` into a local `vtext()` helper
- Replace repeated inline `require()` calls in `init.lua` with module-level locals
- Always set `vim.g.colors_name = "nord"` so lualine's `auto` theme resolves to our theme file regardless of style

## Usage

```lua
require("nord").setup({
  style = "light", -- or "dark" (default)
})
vim.cmd.colorscheme("nord")
```

## Related Files

- `lua/nord/config.lua` — Added `style` option
- `lua/nord/colors.lua` — Added `light_palette`, `color_map`, and color inversion logic
- `lua/nord/init.lua` — Style application, background handling, lualine reload
- `lua/nord/lsp.lua` — Light mode diagnostic virtual text colors
- `lua/nord/terminal.lua` — Light terminal color support
- `lua/nord/utils/init.lua` — `apply_light_mode()` helper
- `lua/lualine/themes/nord.lua` — Lazy palette resolution via `get_theme()`
- `lua/lualine/themes/nord-light.lua` — Delegate to `nord.lua`

## Notes

- Dark theme remains the default for backward compatibility
- All light theme colors stay within the Nord palette
- Compatible with colorblind and transparent modes

## Screenshots

<img width="2942" height="1722" alt="fzf" src="https://github.com/user-attachments/assets/c764fd80-85dc-41b7-ac0e-8261169cf027" />

<img width="2948" height="1724" alt="main-file" src="https://github.com/user-attachments/assets/56ec1a21-e596-4153-a95b-c6073995ab68" />

<img width="2948" height="1724" alt="pop-up" src="https://github.com/user-attachments/assets/e648cb5b-31bb-4b83-912b-16d5cc1b80a0" />

<img width="2944" height="1720" alt="error" src="https://github.com/user-attachments/assets/0e88ac52-2731-457e-a8ec-1bcc188a4dbc" />

<img width="2948" height="1728" alt="warning-popup" src="https://github.com/user-attachments/assets/d4076e48-d5f6-44cf-9dc5-6f8ea48dc9ae" />
