### PR TITLE
feat:Add some extra YAML support

### DIFF
--- a/lua/nord/syntax.lua
+++ b/lua/nord/syntax.lua
@@ -62,6 +62,9 @@ function base.highlights()
     markdownIdDeclaration = { fg = c.frost.polar_water },
     markdownUrl = { fg = c.snow_storm.origin },
 
+    yamlBlockMappingKey = { fg = c.frost.ice },
+    yamlBool = { link = "Boolean" },
+
     debugPC = { bg = utils.darken(c.frost.artic_water, 0.3) }, -- used for highlighting the current line in terminal-debug
     debugBreakpoint = { bg = utils.darken(c.frost.artic_ocean, 0.1), fg = c.frost.artic_water }, -- used for breakpoint colors in terminal-debug
   }


### PR DESCRIPTION
YAML highlighting was almost nonexistent with the code as is.  See before (top) and after (bottom) images:
<img width="823" height="462" alt="Screenshot 2026-04-13 at 8 16 35 PM" src="https://github.com/user-attachments/assets/898a61ea-0ed5-401d-9808-218187095bc7" />
<img width="928" height="461" alt="Screenshot 2026-04-13 at 8 18 42 PM" src="https://github.com/user-attachments/assets/e522287a-0395-4aea-9f6e-3103f0c2af44" />

Hopefully, these changes are acceptable.  If the color selection should be different, let me know.  I'm more than willing to change it.